### PR TITLE
Clean up calculate_diff_ratio

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,16 +74,12 @@ fn validate_image_compatibility(
 
 /// Return a difference ratio between 0 and 1 for the two images
 pub fn calculate_diff_ratio(image1: DynamicImage, image2: DynamicImage) -> f64 {
+    use std::u8;
     // All color types wrap an 8-bit value for each channel
-    let max_val = u64::pow(2, 8) - 1;
-    let mut diffsum: u64 = 0;
-    for (&p1, &p2) in image1.raw_pixels().iter().zip(image2.raw_pixels().iter()) {
-        diffsum += u64::from(abs_diff(p1, p2));
-    }
-    let total_possible = max_val * image1.raw_pixels().len() as u64;
-    let ratio = diffsum as f64 / total_possible as f64;
+    let total_possible = (u8::MAX as usize * image1.raw_pixels().len()) as f64;
 
-    ratio
+    image1.raw_pixels().into_iter().zip(image2.raw_pixels())
+	.map(|(a, b)| abs_diff(a, b) as u64).sum::<u64>() as f64 / total_possible
 }
 
 /// Create an image that is the difference of the two images given, and write to the given filename


### PR DESCRIPTION
Rewrites `calculate_diff_ratio` in a more functional manner, taking advantage of more expressive Rust features.

Reading your excellent [article][article] on comparing programs written in Python, Go and Rust, I found the Rust code snippet a little more imperative and C-like than necessary, so I had some fun trying to see if one could write it as more idiomatic Rust.

[article]: http://www.nicolas-hahn.com/python/go/rust/programming/2019/07/01/program-in-python-go-rust/