### PR TITLE
A few changes to simplify the Rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,12 +89,14 @@ pub fn create_diff_image(
     image2: DynamicImage,
     filename: &str,
 ) -> Result<(), String> {
+    use image::ColorType::*;
+
     let w = image1.width();
     let h = image1.height();
 
     let mut diff = match image1.color() {
-        image::ColorType::RGB(_) => DynamicImage::new_rgb8(w, h),
-        image::ColorType::RGBA(_) => DynamicImage::new_rgba8(w, h),
+        RGB(_) => DynamicImage::new_rgb8(w, h),
+        RGBA(_) => DynamicImage::new_rgba8(w, h),
         _ => return Err(format!("color mode {:?} not yet supported", image1.color())),
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,8 +93,8 @@ pub fn create_diff_image(
     let h = image1.height();
 
     let mut diff = match image1.color() {
-        image::ColorType::RGB(_) => image::DynamicImage::new_rgb8(w, h),
-        image::ColorType::RGBA(_) => image::DynamicImage::new_rgba8(w, h),
+        image::ColorType::RGB(_) => DynamicImage::new_rgb8(w, h),
+        image::ColorType::RGBA(_) => DynamicImage::new_rgba8(w, h),
         _ => return Err(format!("color mode {:?} not yet supported", image1.color())),
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,10 +51,7 @@ fn safe_load_image(raw_path: &str) -> Result<DynamicImage, String> {
         return Err(format!("Path \"{}\" does not exist", raw_path));
     }
 
-    match image::open(path) {
-        Ok(image) => Ok(image),
-        Err(msg) => Err(format!("{:?}", msg)),
-    }
+    image::open(path).map_err(|msg| format!("{:?}", msg))
 }
 
 /// Check if two images are the same size and color mode
@@ -115,11 +112,7 @@ pub fn create_diff_image(
         }
     }
 
-    if let Err(msg) = diff.save(filename) {
-        return Err(msg.to_string());
-    }
-
-    Ok(())
+    diff.save(filename).map_err(|msg| msg.to_string())
 }
 
 /// Run the appropriate diffing process given the configuration settings
@@ -129,17 +122,14 @@ pub fn run(config: Config) -> Result<(), String> {
     validate_image_compatibility(&image1, &image2)?;
 
     match config.filename {
-        Some(filename) => match create_diff_image(image1, image2, filename) {
-            Ok(_) => {
-                println!("Wrote diff image to {}", filename);
-                Ok(())
-            }
-            Err(msg) => Err(msg),
+        Some(filename) => {
+            create_diff_image(image1, image2, filename)?;
+            println!("Wrote diff image to {}", filename);
         },
         None => {
             let ratio = calculate_diff_ratio(image1, image2);
             println!("{}", ratio);
-            return Ok(());
         }
     }
+    Ok(())
 }


### PR DESCRIPTION
These changes should simplify the Rust example a bit. These changes should, I hope, be idiomatic to the language; the only exception is "`Pulling the enum variants into scope`": that style is something I personally find useful, and I'm not certain what the larger Rust community's opinions on it are.