### PR TITLE
Second pass at optimising absolute img diff routine

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ extern crate image;
 use std::path::Path;
 
 use clap::ArgMatches;
-use image::{DynamicImage, GenericImage, GenericImageView};
+use image::{DynamicImage, GenericImageView, RgbImage, RgbaImage};
 
 #[derive(Debug)]
 pub struct Config<'a> {
@@ -95,25 +95,17 @@ pub fn create_diff_image(
     let w = image1.width();
     let h = image1.height();
 
-    let mut diff = match image1.color() {
-        image::ColorType::RGB(_) => image::DynamicImage::new_rgb8(w, h),
-        image::ColorType::RGBA(_) => image::DynamicImage::new_rgba8(w, h),
+
+
+
+    let pix_data : Vec<u8> = image1.raw_pixels().into_iter()
+        .zip(image2.raw_pixels()).map(|(p1, p2)| abs_diff(p1, p2)).collect();
+
+    let diff = match image1.color() {
+        image::ColorType::RGB(_) => DynamicImage::ImageRgb8(RgbImage::from_raw(w, h, pix_data).unwrap()),
+        image::ColorType::RGBA(_) => DynamicImage::ImageRgba8(RgbaImage::from_raw(w, h, pix_data).unwrap()),
         _ => return Err(format!("color mode {:?} not yet supported", image1.color())),
     };
-
-    for x in 0..w {
-        for y in 0..h {
-            let mut rgba = [0; 4];
-            for c in 0..4 {
-                rgba[c] = abs_diff(
-                    image1.get_pixel(x, y).data[c],
-                    image2.get_pixel(x, y).data[c],
-                );
-            }
-            let new_pix = image::Pixel::from_slice(&rgba);
-            diff.put_pixel(x, y, *new_pix);
-        }
-    }
 
     if let Err(msg) = diff.save(filename) {
         return Err(msg.to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,17 +85,21 @@ pub fn create_diff_image(
     image2: DynamicImage,
     filename: &str,
 ) -> Result<(), String> {
-    use image::ColorType::{RGB, RGBA};
+    use image::ColorType;
 
     let w = image1.width();
     let h = image1.height();
 
-    let pix_data : Vec<u8> = image1.raw_pixels().into_iter()
-        .zip(image2.raw_pixels()).map(|(p1, p2)| abs_diff(p1, p2)).collect();
+    let pix_data : Vec<u8> = image1
+        .raw_pixels()
+        .into_iter()
+        .zip(image2.raw_pixels())
+        .map(|(p1, p2)| abs_diff(p1, p2))
+        .collect();
 
     let diff = match image1.color() {
-        RGB(_) => DynamicImage::ImageRgb8(RgbImage::from_raw(w, h, pix_data).unwrap()),
-        RGBA(_) => DynamicImage::ImageRgba8(RgbaImage::from_raw(w, h, pix_data).unwrap()),
+        ColorType::RGB(_) => DynamicImage::ImageRgb8(RgbImage::from_raw(w, h, pix_data).unwrap()),
+        ColorType::RGBA(_) => DynamicImage::ImageRgba8(RgbaImage::from_raw(w, h, pix_data).unwrap()),
         _ => return Err(format!("color mode {:?} not yet supported", image1.color())),
     };
 


### PR DESCRIPTION
Replaced everything by a mostly~ish optimized raw buffer operation. This still does a superfluous data copy (DynamicImage::raw_pixels), but is already over twice as fast

(Tested on the 2000*2000 case)